### PR TITLE
front page fixes

### DIFF
--- a/wavepool/templates/wavepool/frontpage.html
+++ b/wavepool/templates/wavepool/frontpage.html
@@ -12,7 +12,7 @@
 				</div>
 				<div><img src="media/image/placeholder-img.jpg"  width="300" height="175" /></div>
 				<div class="newspost-teaser" data-newspost-id="{{cover_story.pk}}">
-					{{ cover_story.teaser }} ...
+					{{ cover_story.teaser | striptags }} ...
 				</div>
 			</div>
 		</div>
@@ -24,7 +24,7 @@
 						<span class="pubdate">{{newspost.publish_date}}</span>
 						<div class="frontpage-archive_link"><a href="{{ newspost.url }}">{{ newspost.title }}</a></div>
 						<div class="newspost-teaser" data-story_id="{{newspost.pk}}">
-							{{ newspost.teaser  }} ...
+							{{ newspost.teaser | striptags }} ...
 						</div>
 					<hr />
 					</div>
@@ -41,7 +41,7 @@
 						<span class="pubdate">{{newspost.publish_date}}</span>
 						<div class="frontpage-archive_link"><a href="{{ newspost.url }}">{{ newspost.title }}</a></div>
 						<div class="newspost-teaser" data-story_id="{{newspost.pk}}">
-							{{ newspost.teaser  }} ...
+							{{ newspost.teaser  | striptags }} ...
 						</div>
 					</div>
 					<hr />

--- a/wavepool/views.py
+++ b/wavepool/views.py
@@ -14,9 +14,12 @@ def front_page(request):
             archive: the rest of the newsposts, sorted by most recent
     """
     template = loader.get_template('wavepool/frontpage.html')
-    cover_story = NewsPost.objects.all().order_by('?').first()
-    top_stories = NewsPost.objects.all().order_by('?')[:3]
-    other_stories = NewsPost.objects.all().order_by('?')
+    # filter the NewsPost objects to find the one that is the cover story
+    cover_story = NewsPost.objects.all().filter(is_cover_story=True)
+    # filter the NewsPost objects that aren't the cover story and slice the most recent three out
+    top_stories = NewsPost.objects.all().filter(is_cover_story=False).order_by('publish_date')[:3]
+    # filter the next NewsPost objects that aren't the cover story and aren't the most recent three
+    other_stories = NewsPost.objects.all().filter(is_cover_story=False).order_by('publish_date')[3:]
 
     context = {
         'cover_story': cover_story,


### PR DESCRIPTION
Hi!

Here are my changes. It doesn't appear that any of the NewsPost objects have is_cover_story set to True.  Therefore, there won't be a cover story on the front page until a post gets designated as a cover story in the database.

I used Django's built-in "striptags" functionality to get rid of all HTML tags.